### PR TITLE
Add dotnet workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,22 @@
+name: Build site
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Run F# script
+        run: |
+          dotnet fsi build.fsx > output.html
+      - name: Display generated file
+        if: success()
+        run: cat output.html


### PR DESCRIPTION
## Summary
- add a dotnet workflow that builds using `dotnet fsi`
- show generated output only if the script succeeds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844e9899fd4832084806ac58203c6ac