### PR TITLE
Add local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ https://[seu-usuario].github.io/healthcare-stt-demo/
 - 📱 Totalmente responsivo
 
 ## Para demonstração offline
+### Servir localmente
+Para abrir o `index.html` no navegador sem erros de permissão ou CORS, use um servidor HTTP simples.
+
+```bash
+npx serve
+```
+
+```bash
+python -m http.server
+```
+
 Abra o console do navegador (F12) e execute:
 ```javascript
 mockDemo()


### PR DESCRIPTION
## Summary
- document how to serve `index.html` locally
- highlight that using a local server avoids permission/CORS issues

## Testing
- `python -m py_compile` *(fails: missing filenames)*
- `node -v`
- `npx --version`


------
https://chatgpt.com/codex/tasks/task_e_6844e9ad242c83209b9844697616a8e5